### PR TITLE
Adding support for irrigation computer - SGW02

### DIFF
--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -300,6 +300,18 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
             ),
         },
     ),
+    "ggq": TuyaBLECategoryInfo(
+        products={
+            **dict.fromkeys(
+            [
+            "6pahkcau", 
+            "hfgdqhho",
+            ],  # device product_id
+            TuyaBLEProductInfo( 
+                name="Irrigation computer",
+            ),
+        },
+    ),
 }
 
 

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -427,6 +427,30 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                     ),
                 ),
             ],
+            "hfgdqhho": [  # Irrigation computer - SGW02
+                TuyaBLENumberMapping(
+                    dp_id=106,
+                    description=NumberEntityDescription(
+                        key="countdown_duration_z1",
+                        icon="mdi:timer",
+                        native_max_value=1440,
+                        native_min_value=1,
+                        native_unit_of_measurement=TIME_MINUTES,
+                        native_step=1,
+                    ),
+                ),
+                TuyaBLENumberMapping(
+                    dp_id=103,
+                    description=NumberEntityDescription(
+                        key="countdown_duration_z2",
+                        icon="mdi:timer",
+                        native_max_value=1440,
+                        native_min_value=1,
+                        native_unit_of_measurement=TIME_MINUTES,
+                        native_step=1,
+                    ),
+                ),
+            ],
         },
     ),
 }

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -304,6 +304,27 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                     ),
                 ),
             ],
+            "hfgdqhho": [  # Irrigation computer - SGW02
+                TuyaBLEBatteryMapping(dp_id=11),
+                TuyaBLESensorMapping(
+                    dp_id=111,
+                    description=SensorEntityDescription(
+                        key="use_time_z1",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+                TuyaBLESensorMapping(
+                    dp_id=110,
+                    description=SensorEntityDescription(
+                        key="use_time_z2",
+                        device_class=SensorDeviceClass.DURATION,
+                        native_unit_of_measurement=UnitOfTime.SECONDS,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    ),
+                ),
+            ],
         },
     ),
 }

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -64,6 +64,12 @@
       },
       "countdown_duration": {
         "name": "Irrigation duration"
+      },
+      "countdown_duration_z1": {
+        "name": "Irrigation duration - Zone 1"
+      },
+      "countdown_duration_z2": {
+        "name": "Irrigation duration - Zone 2"
       }
     },
     "select": {
@@ -156,6 +162,12 @@
       },
       "time_left": {
           "name": "Remaining irrigation time"
+      },
+      "use_time_z1": {
+          "name": "Last irrigation time - Zone 1"
+      },
+      "use_time_z2": {
+          "name": "Last irrigation time - Zone 2"
       }
     },
     "switch": {
@@ -206,7 +218,13 @@
       },            
       "water_valve": {
           "name": "Irrigation valve"
-      }    
+      },
+      "water_valve_z1": {
+          "name": "Irrigation valve - Zone 1"
+      },
+      "water_valve_z2": {
+          "name": "Irrigation valve - Zone 2"
+      }	  
     },
     "text": {
       "program": {

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -326,6 +326,22 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                     ),
                 ),
             ],
+            "hfgdqhho": [  # Irrigation computer
+                TuyaBLESwitchMapping(
+                    dp_id=105,
+                    description=SwitchEntityDescription(
+                        key="water_valve_z1",
+                        entity_registry_enabled_default=True,
+                    ),
+                ),
+                TuyaBLESwitchMapping(
+                    dp_id=104,
+                    description=SwitchEntityDescription(
+                        key="water_valve_z2",
+                        entity_registry_enabled_default=True,
+                    ),
+                ),
+            ],
         },
     ),
 }

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -49,6 +49,12 @@
             "countdown_duration": {
                 "name": "Irrigation duration"
             },
+            "countdown_duration_z1": {
+                "name": "Irrigation duration - Zone 1"
+            },
+            "countdown_duration_z2": {
+                "name": "Irrigation duration - Zone 2"
+            },
             "down_position": {
                 "name": "Down position"
             },
@@ -148,6 +154,12 @@
             "time_left": {
                 "name": "Remaining irrigation time"
             },
+            "use_time_z1": {
+                "name": "Last irrigation time - Zone 1"
+            },
+            "use_time_z2": {
+                "name": "Last irrigation time - Zone 2"
+            },
             "water_intake": {
                 "name": "Water intake"
             },
@@ -203,6 +215,12 @@
             },
             "water_valve": {
                 "name": "Irrigation valve"
+            },
+            "water_valve_z1": {
+                "name": "Irrigation valve - Zone 1"
+            },
+            "water_valve_z2": {
+                "name": "Irrigation valve - Zone 2"
             },
             "window_check": {
                 "name": "Window Check"


### PR DESCRIPTION
Added the support of SGW02 irrigation computer / smart water valve. Aliexpress link: https://www.aliexpress.com/item/1005005820149207.html It works without gateway, tested with ESPHome Bluetooth Proxy too. First time need to add to Smart Life app in your phone, after Force Close the app, and can be paired in Home Assistant.