### PR TITLE
fix: address security issues found in code review

### DIFF
--- a/custom_components/tuya_ble/__init__.py
+++ b/custom_components/tuya_ble/__init__.py
@@ -49,15 +49,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = TuyaBLECoordinator(hass, device)
 
-    '''
     try:
         await device.update()
     except BLEAK_EXCEPTIONS as ex:
         raise ConfigEntryNotReady(
             f"Could not communicate with Tuya BLE device with address {address}"
         ) from ex
-    '''
-    hass.add_job(device.update())
 
     @callback
     def _async_update_ble(

--- a/custom_components/tuya_ble/cloud.py
+++ b/custom_components/tuya_ble/cloud.py
@@ -1,6 +1,7 @@
 """The Tuya BLE integration."""
 from __future__ import annotations
 
+import hashlib
 import logging
 
 from dataclasses import dataclass
@@ -107,7 +108,9 @@ class HASSTuyaBLEDeviceManager(AbstaractTuyaBLEDeviceManager):
     @staticmethod
     def _get_cache_key(data: dict[str, Any]) -> str:
         key_dict = {key: data.get(key) for key in CONF_TUYA_LOGIN_KEYS}
-        return json.dumps(key_dict)
+        return hashlib.sha256(
+            json.dumps(key_dict, sort_keys=True).encode()
+        ).hexdigest()
 
     @staticmethod
     def _has_login(data: dict[Any, Any]) -> bool:

--- a/custom_components/tuya_ble/config_flow.py
+++ b/custom_components/tuya_ble/config_flow.py
@@ -58,11 +58,16 @@ async def _try_login(
     response: dict[Any, Any] | None
     data: dict[str, Any]
 
-    country = [
+    country_matches = [
         country
         for country in TUYA_COUNTRIES
         if country.name == user_input[CONF_COUNTRY_CODE]
-    ][0]
+    ]
+    if not country_matches:
+        errors["base"] = "login_error"
+        return None
+
+    country = country_matches[0]
 
     data = {
         CONF_ENDPOINT: country.endpoint,
@@ -116,7 +121,7 @@ def _show_login_form(
         def_country = pycountry.countries.get(alpha_2=flow.hass.config.country)
         if def_country:
             def_country_name = def_country.name
-    except:
+    except Exception:
         pass
 
     return flow.async_show_form(

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -274,6 +274,8 @@ class TuyaBLEDevice:
         result += self._device_info.uuid.encode()
         result += self._local_key
         result += self._device_info.device_id.encode()
+        if len(result) > 44:
+            raise TuyaBLEDataFormatError()
         for _ in range(44 - len(result)):
             result += b"\x00"
 
@@ -591,7 +593,7 @@ class TuyaBLEDevice:
                         "%s: communication failed", self.address, exc_info=True
                     )
                     continue
-                except:
+                except Exception:
                     _LOGGER.debug("%s: unexpected error",
                                   self.address, exc_info=True)
                     continue
@@ -604,7 +606,7 @@ class TuyaBLEDevice:
                         await self._client.start_notify(
                             CHARACTERISTIC_NOTIFY, self._notification_handler
                         )
-                    except:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                    except Exception:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
                         self._client = None
                         _LOGGER.error("%s: starting notifications failed",
                                       self.address, exc_info=True)
@@ -628,7 +630,7 @@ class TuyaBLEDevice:
                                 self.address,
                             )
                             continue
-                    except:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                    except Exception:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
                         self._client = None
                         _LOGGER.error("%s: Sending device info request failed",
                                       self.address, exc_info=True)
@@ -651,7 +653,7 @@ class TuyaBLEDevice:
                                 self.address,
                             )
                             continue
-                    except:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
+                    except Exception:  # [BLEAK_EXCEPTIONS, BleakNotFoundError]:
                         self._client = None
                         _LOGGER.error("%s: Sending pairing request failed",
                                       self.address, exc_info=True)
@@ -951,7 +953,7 @@ class TuyaBLEDevice:
                         packet,
                         False,
                     )
-                except:
+                except Exception:
                     _LOGGER.error(
                         "%s: Error during sending packet",
                         self.address,
@@ -976,7 +978,7 @@ class TuyaBLEDevice:
         elif security_flag == 5:
             return self._session_key
         else:
-            pass
+            raise TuyaBLEDataFormatError()
 
     def _parse_timestamp(self, data: bytes, start_pos: int) -> tuple(float, int):
         timestamp: float


### PR DESCRIPTION
## Security fixes

This PR addresses 6 security issues identified in a code review.

### Changes

**`tuya_ble/tuya_ble.py`**
- **Encryption bypass via `None` key** — `_get_key()` silently returned `None` for unknown security flag values, which would cause `AES.new(None, ...)` to raise a cryptic error rather than clearly rejecting the packet. Now raises `TuyaBLEDataFormatError()` explicitly.
- **Pairing request buffer overflow** — `_build_pairing_request()` would silently enter a negative-count loop if `uuid + local_key + device_id` exceeded 44 bytes. Added a length guard that raises `TuyaBLEDataFormatError()` before the padding loop.
- **Bare `except:` clauses** — Three `except:` blocks (in `_ensure_connected` and `_int_send_packets_locked`) were catching `SystemExit` and `KeyboardInterrupt`, preventing clean process shutdown. Changed to `except Exception:`.

**`config_flow.py`**
- **Unguarded `IndexError`** — `_try_login()` accessed `[0]` on a country list comprehension without checking if the list was empty. If the submitted country name didn't match any entry in `TUYA_COUNTRIES`, it would raise an unhandled `IndexError`. Added a guard with a user-facing `login_error`.
- **Bare `except:` clause** — `_show_login_form()` had a bare `except:`. Changed to `except Exception:`.

**`cloud.py`**
- **Credentials in cache key** — `_get_cache_key()` used a plain JSON serialisation of login credentials (including `password` and `access_secret`) as a dict key. These values were therefore visible in memory dumps / debug logs. Now uses SHA-256 of the serialised dict as the cache key.
- Added `import hashlib`.

**`__init__.py`**
- **Silent BLE errors on setup** — `device.update()` was called without error handling, meaning BLE connection failures during integration setup were silently discarded. Restored the `try/except BLEAK_EXCEPTIONS` block that raises `ConfigEntryNotReady`, allowing Home Assistant to retry the setup correctly.